### PR TITLE
Driven Adapters Layer (Loan microservice)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -334,3 +334,6 @@ gradle-app.setting
 # -----
 *.hprof
 build-cache
+
+#Environmental variables
+**/.env

--- a/applications/app-service/build.gradle
+++ b/applications/app-service/build.gradle
@@ -1,12 +1,17 @@
 apply plugin: 'org.springframework.boot'
 
 dependencies {
+	implementation 'org.reactivecommons.utils:object-mapper:0.1.0'
+	implementation project(':r2dbc-postgresql')
     implementation project(':model')
     implementation project(':usecase')
     implementation 'org.springframework.boot:spring-boot-starter'
     runtimeOnly('org.springframework.boot:spring-boot-devtools')
     testImplementation 'com.tngtech.archunit:archunit:1.4.1'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind'
+
+    // https://mvnrepository.com/artifact/me.paulschwarz/spring-dotenv
+    implementation "me.paulschwarz:spring-dotenv:${dotenvVersion}"
 }
 
 tasks.register('explodedJar', Copy) {
@@ -23,4 +28,3 @@ bootJar {
     // Sets output jar name
     archiveFileName = "${project.getParent().getName()}.${archiveExtension.get()}"
 }
-

--- a/applications/app-service/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/config/ObjectMapperConfig.java
+++ b/applications/app-service/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/config/ObjectMapperConfig.java
@@ -1,0 +1,16 @@
+package co.com.powerup.crediya.santiagomh04.msvcloanrequests.config;
+
+import org.reactivecommons.utils.ObjectMapper;
+import org.reactivecommons.utils.ObjectMapperImp;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ObjectMapperConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapperImp();
+    }
+
+}

--- a/applications/app-service/src/main/resources/application.yaml
+++ b/applications/app-service/src/main/resources/application.yaml
@@ -1,6 +1,6 @@
 ##Spring Configuration
 server:
-  port: 8080
+  port: 8081
 spring:
   application:
     name: msvc-loan-requests
@@ -12,3 +12,12 @@ spring:
       path: /h2
   profiles:
     include:
+
+adapters:
+  r2dbc:
+    host: ${POSTGRESQL_HOST}
+    port: ${POSTGRESQL_PORT}
+    database: ${POSTGRESQL_DATABASE}
+    schema: ${POSTGRESQL_SCHEMA}
+    username: ${POSTGRESQL_USERNAME}
+    password: ${POSTGRESQL_PASSWORD}

--- a/applications/app-service/src/test/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/config/ObjectMapperConfigTest.java
+++ b/applications/app-service/src/test/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/config/ObjectMapperConfigTest.java
@@ -1,0 +1,20 @@
+package co.com.powerup.crediya.santiagomh04.msvcloanrequests.config;
+
+import org.junit.jupiter.api.Test;
+import org.reactivecommons.utils.ObjectMapper;
+import org.reactivecommons.utils.ObjectMapperImp;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ObjectMapperConfigTest {
+
+    @Test
+    void testObjectMapperBean() {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(ObjectMapperConfig.class);
+        ObjectMapper objectMapper = context.getBean(ObjectMapper.class);
+        assertNotNull(objectMapper);
+        assertTrue(objectMapper instanceof ObjectMapperImp);
+        context.close();
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ buildscript {
 		jacocoVersion = '0.8.13'
 		pitestVersion = '1.19.0-rc.1'
         lombokVersion = '1.18.38'
+        dotenvVersion = '4.0.0'
 	}
 }
 

--- a/domain/model/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/model/loan/gateways/LoanRepository.java
+++ b/domain/model/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/model/loan/gateways/LoanRepository.java
@@ -1,7 +1,6 @@
 package co.com.powerup.crediya.santiagomh04.msvcloanrequests.model.loan.gateways;
 
 import co.com.powerup.crediya.santiagomh04.msvcloanrequests.model.loan.Loan;
-import co.com.powerup.crediya.santiagomh04.msvcloanrequests.model.loan.utils.LoanStatus;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -9,6 +8,6 @@ import java.util.UUID;
 
 public interface LoanRepository {
     Mono<Loan> createLoan(Loan loan);
-    Mono<Loan> updateLoanStatus(UUID loanId, LoanStatus newStatus);
+    Mono<Loan> updateLoanStatus(UUID loanId, String newStatus);
     Flux<Loan> findByIdentificationNumber(String identificationNumber);
 }

--- a/domain/model/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/model/loan/utils/LoanStatus.java
+++ b/domain/model/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/model/loan/utils/LoanStatus.java
@@ -1,7 +1,0 @@
-package co.com.powerup.crediya.santiagomh04.msvcloanrequests.model.loan.utils;
-
-public enum LoanStatus {
-    PENDING_OF_REVISION,
-    APPROVED,
-    REJECTED;
-}

--- a/domain/model/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/model/loantype/gateways/LoanTypeRepository.java
+++ b/domain/model/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/model/loantype/gateways/LoanTypeRepository.java
@@ -7,4 +7,6 @@ import reactor.core.publisher.Mono;
 public interface LoanTypeRepository {
     Mono<LoanType> createLoanType(LoanType loanType);
     Flux<LoanType> findAll();
+    Mono<LoanType> findById(Long id);
+    Mono<LoanType> findByName(String name);
 }

--- a/domain/usecase/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/usecase/loan/ILoanUseCase.java
+++ b/domain/usecase/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/usecase/loan/ILoanUseCase.java
@@ -2,7 +2,6 @@ package co.com.powerup.crediya.santiagomh04.msvcloanrequests.usecase.loan;
 
 import co.com.powerup.crediya.santiagomh04.msvcloanrequests.model.loan.Loan;
 import co.com.powerup.crediya.santiagomh04.msvcloanrequests.model.loan.gateways.LoanRepository;
-import co.com.powerup.crediya.santiagomh04.msvcloanrequests.model.loan.utils.LoanStatus;
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -16,11 +15,13 @@ public class ILoanUseCase implements LoanUseCase{
 
     @Override
     public Mono<Loan> create(Loan loan) {
+        //Assign status PENDING_OF_REVISION by default
+        loan.setStatus(Loan.LoanStatus.PENDING_OF_REVISION.name());
         return this.repoLoan.createLoan(loan);
     }
 
     @Override
-    public Mono<Loan> updateLoanStatus(UUID loanId, LoanStatus newStatus) {
+    public Mono<Loan> updateLoanStatus(UUID loanId, String newStatus) {
         return this.repoLoan.updateLoanStatus(loanId, newStatus);
     }
 

--- a/domain/usecase/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/usecase/loan/LoanUseCase.java
+++ b/domain/usecase/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/usecase/loan/LoanUseCase.java
@@ -1,7 +1,6 @@
 package co.com.powerup.crediya.santiagomh04.msvcloanrequests.usecase.loan;
 
 import co.com.powerup.crediya.santiagomh04.msvcloanrequests.model.loan.Loan;
-import co.com.powerup.crediya.santiagomh04.msvcloanrequests.model.loan.utils.LoanStatus;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -9,6 +8,6 @@ import java.util.UUID;
 
 public interface LoanUseCase {
     Mono<Loan> create(Loan loan);
-    Mono<Loan> updateLoanStatus(UUID loanId, LoanStatus newStatus);
+    Mono<Loan> updateLoanStatus(UUID loanId, String newStatus);
     Flux<Loan> findByClientIdentificationNumber(String identificationNumber);
 }

--- a/domain/usecase/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/usecase/loanType/ILoanTypeUseCase.java
+++ b/domain/usecase/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/usecase/loanType/ILoanTypeUseCase.java
@@ -1,4 +1,4 @@
-package co.com.powerup.crediya.santiagomh04.msvcloanrequests.usecase.loantype;
+package co.com.powerup.crediya.santiagomh04.msvcloanrequests.usecase.loanType;
 
 import co.com.powerup.crediya.santiagomh04.msvcloanrequests.model.loantype.LoanType;
 import co.com.powerup.crediya.santiagomh04.msvcloanrequests.model.loantype.gateways.LoanTypeRepository;
@@ -7,7 +7,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @RequiredArgsConstructor
-public class ILoanTypeUseCase implements LoanUseCase{
+public class ILoanTypeUseCase implements LoanTypeUseCase {
 
     private final LoanTypeRepository repoLoanType;
 
@@ -19,5 +19,15 @@ public class ILoanTypeUseCase implements LoanUseCase{
     @Override
     public Flux<LoanType> findAll() {
         return this.repoLoanType.findAll();
+    }
+
+    @Override
+    public Mono<LoanType> findById(Long id) {
+        return this.repoLoanType.findById(id);
+    }
+
+    @Override
+    public Mono<LoanType> findByName(String name) {
+        return this.repoLoanType.findByName(name);
     }
 }

--- a/domain/usecase/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/usecase/loanType/LoanTypeUseCase.java
+++ b/domain/usecase/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/usecase/loanType/LoanTypeUseCase.java
@@ -1,10 +1,12 @@
-package co.com.powerup.crediya.santiagomh04.msvcloanrequests.usecase.loantype;
+package co.com.powerup.crediya.santiagomh04.msvcloanrequests.usecase.loanType;
 
 import co.com.powerup.crediya.santiagomh04.msvcloanrequests.model.loantype.LoanType;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-public interface LoanUseCase {
+public interface LoanTypeUseCase {
     Mono<LoanType> createLoanType(LoanType loanType);
     Flux<LoanType> findAll();
+    Mono<LoanType> findById(Long id);
+    Mono<LoanType> findByName(String name);
 }

--- a/infrastructure/driven-adapters/r2dbc-postgresql/build.gradle
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/build.gradle
@@ -1,0 +1,11 @@
+dependencies {
+    implementation project(':model')
+    implementation 'org.springframework:spring-context'
+    implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
+    implementation 'jakarta.persistence:jakarta.persistence-api' // TODO: Check if it's still necessary
+    implementation 'org.postgresql:r2dbc-postgresql'
+    implementation 'org.reactivecommons.utils:object-mapper-api:0.1.0'
+
+    testImplementation 'org.reactivecommons.utils:object-mapper:0.1.0'
+}
+

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/r2dbc/adapters/LoanReactiveRepositoryAdapter.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/r2dbc/adapters/LoanReactiveRepositoryAdapter.java
@@ -1,0 +1,43 @@
+package co.com.powerup.crediya.santiagomh04.msvcloanrequests.r2dbc.adapters;
+
+import co.com.powerup.crediya.santiagomh04.msvcloanrequests.model.loan.Loan;
+import co.com.powerup.crediya.santiagomh04.msvcloanrequests.model.loan.gateways.LoanRepository;
+import co.com.powerup.crediya.santiagomh04.msvcloanrequests.r2dbc.entities.LoanEntity;
+import co.com.powerup.crediya.santiagomh04.msvcloanrequests.r2dbc.mappers.LoanMapper;
+import co.com.powerup.crediya.santiagomh04.msvcloanrequests.r2dbc.repositories.LoanReactiveRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class LoanReactiveRepositoryAdapter implements LoanRepository {
+
+    private final LoanReactiveRepository repoLoanReactive;
+    private final LoanMapper loanMapper;
+
+    @Override
+    public Mono<Loan> createLoan(Loan loan) {
+        return this.repoLoanReactive.save(this.loanMapper.toEntity(loan))
+            .flatMap(this.loanMapper::toDomain);
+    }
+
+    @Override
+    public Mono<Loan> updateLoanStatus(UUID loanId, String newStatus) {
+        return this.repoLoanReactive.findById(loanId)
+        .flatMap(le -> {
+            le.setStatus(LoanEntity.LoanStatus.valueOf(newStatus).name());
+            return this.repoLoanReactive.save(le);
+        })
+        .flatMap(this.loanMapper::toDomain);
+    }
+
+    @Override
+    public Flux<Loan> findByIdentificationNumber(String identificationNumber) {
+        return this.repoLoanReactive.findByIdentificationNumber(identificationNumber)
+            .flatMap(this.loanMapper::toDomain);
+    }
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/r2dbc/adapters/LoanTypeReactiveRepositoryAdapter.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/r2dbc/adapters/LoanTypeReactiveRepositoryAdapter.java
@@ -1,0 +1,42 @@
+package co.com.powerup.crediya.santiagomh04.msvcloanrequests.r2dbc.adapters;
+
+import co.com.powerup.crediya.santiagomh04.msvcloanrequests.model.loantype.LoanType;
+import co.com.powerup.crediya.santiagomh04.msvcloanrequests.model.loantype.gateways.LoanTypeRepository;
+import co.com.powerup.crediya.santiagomh04.msvcloanrequests.r2dbc.mappers.LoanTypeMapper;
+import co.com.powerup.crediya.santiagomh04.msvcloanrequests.r2dbc.repositories.LoanTypeReactiveRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Repository
+@RequiredArgsConstructor
+public class LoanTypeReactiveRepositoryAdapter implements LoanTypeRepository {
+
+    private final LoanTypeReactiveRepository repoLoanType;
+    private final LoanTypeMapper loanTypeMapper;
+
+    @Override
+    public Mono<LoanType> createLoanType(LoanType loanType) {
+        return this.repoLoanType.save(this.loanTypeMapper.toEntity(loanType))
+            .map(this.loanTypeMapper::toDomain);
+    }
+
+    @Override
+    public Flux<LoanType> findAll() {
+        return this.repoLoanType.findAll()
+            .map(this.loanTypeMapper::toDomain);
+    }
+
+    @Override
+    public Mono<LoanType> findById(Long id) {
+        return this.repoLoanType.findById(id)
+            .map(this.loanTypeMapper::toDomain);
+    }
+
+    @Override
+    public Mono<LoanType> findByName(String name) {
+        return this.repoLoanType.findByName(name)
+            .map(this.loanTypeMapper::toDomain);
+    }
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/r2dbc/config/PostgreSQLConnectionPool.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/r2dbc/config/PostgreSQLConnectionPool.java
@@ -1,0 +1,42 @@
+package co.com.powerup.crediya.santiagomh04.msvcloanrequests.r2dbc.config;
+
+import io.r2dbc.pool.ConnectionPool;
+import io.r2dbc.pool.ConnectionPoolConfiguration;
+import io.r2dbc.postgresql.PostgresqlConnectionConfiguration;
+import io.r2dbc.postgresql.PostgresqlConnectionFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+@Configuration
+public class PostgreSQLConnectionPool {
+    /* Change these values for your project */
+    public static final int INITIAL_SIZE = 12;
+    public static final int MAX_SIZE = 15;
+    public static final int MAX_IDLE_TIME = 30;
+    public static final int DEFAULT_PORT = 5432;
+
+	@Bean
+	public ConnectionPool getConnectionConfig(PostgreSQLConnectionProperties properties) {
+		PostgresqlConnectionConfiguration dbConfiguration = PostgresqlConnectionConfiguration.builder()
+                .host(properties.host())
+                .port(properties.port())
+                .database(properties.database())
+                .schema(properties.schema())
+                .username(properties.username())
+                .password(properties.password())
+                .build();
+
+        ConnectionPoolConfiguration poolConfiguration = ConnectionPoolConfiguration.builder()
+                .connectionFactory(new PostgresqlConnectionFactory(dbConfiguration))
+                .name("api-postgres-connection-pool")
+                .initialSize(INITIAL_SIZE)
+                .maxSize(MAX_SIZE)
+                .maxIdleTime(Duration.ofMinutes(MAX_IDLE_TIME))
+                .validationQuery("SELECT 1")
+                .build();
+
+		return new ConnectionPool(poolConfiguration);
+	}
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/r2dbc/config/PostgreSQLConnectionProperties.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/r2dbc/config/PostgreSQLConnectionProperties.java
@@ -1,0 +1,14 @@
+package co.com.powerup.crediya.santiagomh04.msvcloanrequests.r2dbc.config;
+
+// TODO: Load properties from the application.yaml file or from secrets manager
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "adapters.r2dbc")
+public record PostgreSQLConnectionProperties(
+    String host,
+    Integer port,
+    String database,
+    String schema,
+    String username,
+    String password) {
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/r2dbc/entities/LoanEntity.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/r2dbc/entities/LoanEntity.java
@@ -1,30 +1,43 @@
-package co.com.powerup.crediya.santiagomh04.msvcloanrequests.model.loan;
+package co.com.powerup.crediya.santiagomh04.msvcloanrequests.r2dbc.entities;
 
-import co.com.powerup.crediya.santiagomh04.msvcloanrequests.model.loantype.LoanType;
-import lombok.Builder;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
+import lombok.Builder;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.UUID;
 
-@Getter
-@Setter
+@Data
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder(toBuilder = true)
-public class Loan {
+@Builder
+@Table("loans")
+public class LoanEntity {
+    @Id
     private UUID loanId;
+
+    @Column("name")
     private String identificationNumber;    //Just the identification number, and not the whole user, in order to separate responsibilities
+
+    @Column("adjudication_date")
     private LocalDate adjudicationDate;
+
+    @Column("deadline")
     private int deadline;   //The deadline will be measured in months
-    private LoanType loanType;
+
+    @Column("loan_type_id")
+    private Long loanTypeId;
+
+    @Column("amount")
     private BigDecimal amount;
+
+    @Column("status")
     private String status;
-        /*private LoanStatus status;*/
 
     public enum LoanStatus {
         PENDING_OF_REVISION,

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/r2dbc/entities/LoanTypeEntity.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/r2dbc/entities/LoanTypeEntity.java
@@ -1,0 +1,34 @@
+package co.com.powerup.crediya.santiagomh04.msvcloanrequests.r2dbc.entities;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table("loan_types")
+public class LoanTypeEntity {
+    @Id
+    private Long id;
+
+    @Column("name")
+    private String name;
+
+    @Column("interest_rate")
+    private BigDecimal interestRate;
+
+    @Column("minimum_base_salary")
+    private BigInteger minimumBaseSalary;
+
+    @Column("maximum_deadline")
+    private int maximumDeadline;
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/r2dbc/helper/ReactiveAdapterOperations.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/r2dbc/helper/ReactiveAdapterOperations.java
@@ -1,0 +1,67 @@
+package co.com.powerup.crediya.santiagomh04.msvcloanrequests.r2dbc.helper;
+
+import org.reactivecommons.utils.ObjectMapper;
+import org.springframework.data.domain.Example;
+import org.springframework.data.repository.query.ReactiveQueryByExampleExecutor;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.lang.reflect.ParameterizedType;
+import java.util.function.Function;
+
+public abstract class ReactiveAdapterOperations<E, D, I, R extends ReactiveCrudRepository<D, I> & ReactiveQueryByExampleExecutor<D>> {
+    protected R repository;
+    protected ObjectMapper mapper;
+    private final Class<D> dataClass;
+    private final Function<D, E> toEntityFn;
+
+    @SuppressWarnings("unchecked")
+    protected ReactiveAdapterOperations(R repository, ObjectMapper mapper, Function<D, E> toEntityFn) {
+        this.repository = repository;
+        this.mapper = mapper;
+        ParameterizedType genericSuperclass = (ParameterizedType) this.getClass().getGenericSuperclass();
+        this.dataClass = (Class<D>) genericSuperclass.getActualTypeArguments()[1];
+        this.toEntityFn = toEntityFn;
+    }
+
+    protected D toData(E entity) {
+        return mapper.map(entity, dataClass);
+    }
+
+    protected E toEntity(D data) {
+        return data != null ? toEntityFn.apply(data) : null;
+    }
+
+    public Mono<E> save(E entity) {
+        return saveData(toData(entity))
+                .map(this::toEntity);
+    }
+
+    protected Flux<E> saveAllEntities(Flux<E> entities) {
+        return saveData(entities.map(this::toData))
+                .map(this::toEntity);
+    }
+
+    protected Mono<D> saveData(D data) {
+        return repository.save(data);
+    }
+
+    protected Flux<D> saveData(Flux<D> data) {
+        return repository.saveAll(data);
+    }
+
+    public Mono<E> findById(I id) {
+        return repository.findById(id).map(this::toEntity);
+    }
+
+    public Flux<E> findByExample(E entity) {
+        return repository.findAll(Example.of(toData(entity)))
+                .map(this::toEntity);
+    }
+
+    public Flux<E> findAll() {
+        return repository.findAll()
+                .map(this::toEntity);
+    }
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/r2dbc/mappers/LoanMapper.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/r2dbc/mappers/LoanMapper.java
@@ -1,0 +1,39 @@
+package co.com.powerup.crediya.santiagomh04.msvcloanrequests.r2dbc.mappers;
+
+import co.com.powerup.crediya.santiagomh04.msvcloanrequests.model.loan.Loan;
+import co.com.powerup.crediya.santiagomh04.msvcloanrequests.model.loantype.LoanType;
+import co.com.powerup.crediya.santiagomh04.msvcloanrequests.model.loantype.gateways.LoanTypeRepository;
+import co.com.powerup.crediya.santiagomh04.msvcloanrequests.r2dbc.entities.LoanEntity;
+import lombok.RequiredArgsConstructor;
+import org.reactivecommons.utils.ObjectMapper;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+public class LoanMapper {
+
+    private final ObjectMapper objectMapper;
+    private final LoanTypeRepository repoLoanType;
+
+    public Mono<Loan> toDomain(LoanEntity loanEntity){
+        Loan loan = this.objectMapper.map(loanEntity, Loan.class);
+
+        return this.repoLoanType.findById(loanEntity.getLoanTypeId())
+            .flatMap(loanTypeEntity -> {
+                LoanType loanType = this.objectMapper.map(loanTypeEntity, LoanType.class);
+                loan.setLoanType(loanType);
+                return Mono.just(loan);
+            });
+    }
+
+    public LoanEntity toEntity(Loan loan){
+        LoanEntity loanEntity = this.objectMapper.map(loan, LoanEntity.class);
+
+        if (loan.getLoanType() != null){
+            loanEntity.setLoanTypeId(loan.getLoanType().getId());
+        }
+
+        return loanEntity;
+    }
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/r2dbc/mappers/LoanTypeMapper.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/r2dbc/mappers/LoanTypeMapper.java
@@ -1,0 +1,22 @@
+package co.com.powerup.crediya.santiagomh04.msvcloanrequests.r2dbc.mappers;
+
+import co.com.powerup.crediya.santiagomh04.msvcloanrequests.model.loantype.LoanType;
+import co.com.powerup.crediya.santiagomh04.msvcloanrequests.r2dbc.entities.LoanTypeEntity;
+import lombok.RequiredArgsConstructor;
+import org.reactivecommons.utils.ObjectMapper;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LoanTypeMapper {
+
+    private final ObjectMapper objectMapper;
+
+    public LoanType toDomain(LoanTypeEntity loanTypeEntity){
+        return this.objectMapper.map(loanTypeEntity, LoanType.class);
+    }
+
+    public LoanTypeEntity toEntity(LoanType loanType){
+        return this.objectMapper.map(loanType, LoanTypeEntity.class);
+    }
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/r2dbc/repositories/LoanReactiveRepository.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/r2dbc/repositories/LoanReactiveRepository.java
@@ -1,0 +1,11 @@
+package co.com.powerup.crediya.santiagomh04.msvcloanrequests.r2dbc.repositories;
+
+import co.com.powerup.crediya.santiagomh04.msvcloanrequests.r2dbc.entities.LoanEntity;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
+
+import java.util.UUID;
+
+public interface LoanReactiveRepository extends ReactiveCrudRepository<LoanEntity, UUID> {
+    Flux<LoanEntity> findByIdentificationNumber(String identificationNumber);
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/r2dbc/repositories/LoanTypeReactiveRepository.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/r2dbc/repositories/LoanTypeReactiveRepository.java
@@ -1,0 +1,10 @@
+package co.com.powerup.crediya.santiagomh04.msvcloanrequests.r2dbc.repositories;
+
+import co.com.powerup.crediya.santiagomh04.msvcloanrequests.r2dbc.entities.LoanTypeEntity;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Mono;
+
+
+public interface LoanTypeReactiveRepository extends ReactiveCrudRepository<LoanTypeEntity, Long> {
+    Mono<LoanTypeEntity> findByName(String name);
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/r2dbc/MyReactiveRepositoryAdapterTest.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/r2dbc/MyReactiveRepositoryAdapterTest.java
@@ -1,0 +1,78 @@
+package co.com.powerup.crediya.santiagomh04.msvcloanrequests.r2dbc;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.reactivecommons.utils.ObjectMapper;
+import org.springframework.data.domain.Example;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MyReactiveRepositoryAdapterTest {
+    // TODO: change four you own tests
+
+    /*@InjectMocks
+    MyReactiveRepositoryAdapter repositoryAdapter;
+
+    @Mock
+    MyReactiveRepository repository;
+
+    @Mock
+    ObjectMapper mapper;
+
+    @Test
+    void mustFindValueById() {
+
+        when(repository.findById("1")).thenReturn(Mono.just("test"));
+        when(mapper.map("test", Object.class)).thenReturn("test");
+
+        Mono<Object> result = repositoryAdapter.findById("1");
+
+        StepVerifier.create(result)
+                .expectNextMatches(value -> value.equals("test"))
+                .verifyComplete();
+    }
+
+    @Test
+    void mustFindAllValues() {
+        when(repository.findAll()).thenReturn(Flux.just("test"));
+        when(mapper.map("test", Object.class)).thenReturn("test");
+
+        Flux<Object> result = repositoryAdapter.findAll();
+
+        StepVerifier.create(result)
+                .expectNextMatches(value -> value.equals("test"))
+                .verifyComplete();
+    }
+
+    @Test
+    void mustFindByExample() {
+        when(repository.findAll(any(Example.class))).thenReturn(Flux.just("test"));
+        when(mapper.map("test", Object.class)).thenReturn("test");
+
+        Flux<Object> result = repositoryAdapter.findByExample("test");
+
+        StepVerifier.create(result)
+                .expectNextMatches(value -> value.equals("test"))
+                .verifyComplete();
+    }
+
+    @Test
+    void mustSaveValue() {
+        when(repository.save("test")).thenReturn(Mono.just("test"));
+        when(mapper.map("test", Object.class)).thenReturn("test");
+
+        Mono<Object> result = repositoryAdapter.save("test");
+
+        StepVerifier.create(result)
+                .expectNextMatches(value -> value.equals("test"))
+                .verifyComplete();
+    }*/
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/r2dbc/config/PostgreSQLConnectionPoolTest.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/r2dbc/config/PostgreSQLConnectionPoolTest.java
@@ -1,0 +1,37 @@
+package co.com.powerup.crediya.santiagomh04.msvcloanrequests.r2dbc.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+class PostgreSQLConnectionPoolTest {
+
+    @InjectMocks
+    private PostgreSQLConnectionPool connectionPool;
+
+    @Mock
+    private PostgreSQLConnectionProperties properties;
+
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        when(properties.host()).thenReturn("localhost");
+        when(properties.port()).thenReturn(5432);
+        when(properties.database()).thenReturn("dbName");
+        when(properties.schema()).thenReturn("schema");
+        when(properties.username()).thenReturn("username");
+        when(properties.password()).thenReturn("password");
+    }
+
+    @Test
+    void getConnectionConfigSuccess() {
+        assertNotNull(connectionPool.getConnectionConfig(properties));
+    }
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/r2dbc/helper/ReactiveAdapterOperationsTest.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/powerup/crediya/santiagomh04/msvcloanrequests/r2dbc/helper/ReactiveAdapterOperationsTest.java
@@ -1,0 +1,168 @@
+package co.com.powerup.crediya.santiagomh04.msvcloanrequests.r2dbc.helper;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.reactivecommons.utils.ObjectMapper;
+import org.springframework.data.domain.Example;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import org.springframework.data.repository.query.ReactiveQueryByExampleExecutor;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.Objects;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class ReactiveAdapterOperationsTest {
+
+    private DummyRepository repository;
+    private ObjectMapper mapper;
+    private ReactiveAdapterOperations<DummyEntity, DummyData, String, DummyRepository> operations;
+
+    @BeforeEach
+    void setUp() {
+        repository = Mockito.mock(DummyRepository.class);
+        mapper = Mockito.mock(ObjectMapper.class);
+        operations = new ReactiveAdapterOperations<DummyEntity, DummyData, String, DummyRepository>(
+                repository, mapper, DummyEntity::toEntity) {};
+    }
+
+    @Test
+    void save() {
+        DummyEntity entity = new DummyEntity("1", "test");
+        DummyData data = new DummyData("1", "test");
+
+        when(mapper.map(entity, DummyData.class)).thenReturn(data);
+        when(repository.save(data)).thenReturn(Mono.just(data));
+
+        StepVerifier.create(operations.save(entity))
+                .expectNext(entity)
+                .verifyComplete();
+    }
+
+    @Test
+    void saveAllEntities() {
+        DummyEntity entity1 = new DummyEntity("1", "test1");
+        DummyEntity entity2 = new DummyEntity("2", "test2");
+        DummyData data1 = new DummyData("1", "test1");
+        DummyData data2 = new DummyData("2", "test2");
+
+        when(mapper.map(entity1, DummyData.class)).thenReturn(data1);
+        when(mapper.map(entity2, DummyData.class)).thenReturn(data2);
+        when(repository.saveAll(any(Flux.class))).thenReturn(Flux.just(data1, data2));
+
+        StepVerifier.create(operations.saveAllEntities(Flux.just(entity1, entity2)))
+                .expectNext(entity1, entity2)
+                .verifyComplete();
+    }
+
+    @Test
+    void findById() {
+        DummyData data = new DummyData("1", "test");
+        DummyEntity entity = new DummyEntity("1", "test");
+
+        when(repository.findById("1")).thenReturn(Mono.just(data));
+
+        StepVerifier.create(operations.findById("1"))
+                .expectNext(entity)
+                .verifyComplete();
+    }
+
+    @Test
+    void findByExample() {
+        DummyEntity entity = new DummyEntity("1", "test");
+        DummyData data = new DummyData("1", "test");
+
+        when(mapper.map(entity, DummyData.class)).thenReturn(data);
+        when(repository.findAll(any(Example.class))).thenReturn(Flux.just(data));
+
+        StepVerifier.create(operations.findByExample(entity))
+                .expectNext(entity)
+                .verifyComplete();
+    }
+
+    @Test
+    void findAll() {
+        DummyData data1 = new DummyData("1", "test1");
+        DummyData data2 = new DummyData("2", "test2");
+        DummyEntity entity1 = new DummyEntity("1", "test1");
+        DummyEntity entity2 = new DummyEntity("2", "test2");
+
+        when(repository.findAll()).thenReturn(Flux.just(data1, data2));
+
+        StepVerifier.create(operations.findAll())
+                .expectNext(entity1, entity2)
+                .verifyComplete();
+    }
+
+    static class DummyEntity {
+        private String id;
+        private String name;
+
+        public DummyEntity(String id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        public static DummyEntity toEntity(DummyData data) {
+            return new DummyEntity(data.getId(), data.getName());
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            DummyEntity that = (DummyEntity) o;
+            return id.equals(that.id) && name.equals(that.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id, name);
+        }
+    }
+
+    static class DummyData {
+        private String id;
+        private String name;
+
+        public DummyData(String id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            DummyData that = (DummyData) o;
+            return id.equals(that.id) && name.equals(that.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id, name);
+        }
+    }
+
+    interface DummyRepository extends ReactiveCrudRepository<DummyData, String>, ReactiveQueryByExampleExecutor<DummyData> {}
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,3 +20,5 @@ include ':usecase'
 project(':app-service').projectDir = file('./applications/app-service')
 project(':model').projectDir = file('./domain/model')
 project(':usecase').projectDir = file('./domain/usecase')
+include ':r2dbc-postgresql'
+project(':r2dbc-postgresql').projectDir = file('./infrastructure/driven-adapters/r2dbc-postgresql')


### PR DESCRIPTION
This pull request completes the implementation of the driven-adapters layer for the Loan microservice, enabling full persistence of loan requests using PostgreSQL and reactive programming via R2DBC.

**🔹 Technologies & Strategy**
- Database: PostgreSQL
- Persistence Layer: Spring Data R2DBC
- Reactive Programming: All operations are non-blocking and return Mono/Flux types.
- Mapping: Explicit separation between domain models and persistence entities using dedicated mappers.

**🔹 Entities**
- LoanEntity: Represents the persisted loan request, including identification number, amount, deadline, adjudication date, loan type ID, and status.
- LoanTypeEntity: Encapsulates loan type rules such as interest rate, minimum base salary, and maximum deadline.

**🔹 Repository Adapters**
- ReactiveRepositoryAdapter: Implements domain interfaces (LoanRepository, LoanTypeRepository) using reactive R2DBC repositories.
- Includes methods for:
- Creating loan requests.
- Updating loan status.
- Retrieving loans by identification number.
- Creating and listing loan types.

**🔹 Design Principles**
- Clean separation between domain and persistence layers.
- No exception handling within adapters to preserve purity; error management is delegated to upper layers.
- Enum mapping handled natively by R2DBC without JPA annotations like `@Enumerated.`

**🔹 Outcome**
- The microservice is now capable of persisting and retrieving loan-related data in a fully reactive, scalable, and decoupled manner.
- This layer completes the infrastructure required to support the domain use cases and prepares the system for integration with entry-points and external services.
